### PR TITLE
PRODENG-3461 feature: disable sshd after install

### DIFF
--- a/ansible/mke-install-playbook.yml
+++ b/ansible/mke-install-playbook.yml
@@ -39,3 +39,13 @@
     - vars/mke-creds.yml
   tasks:
     - ansible.builtin.include_tasks: tasks/mke-install-tasks.yml
+
+
+- name: Disable sshd on all hosts after MKE installation
+  hosts: all
+  gather_facts: false
+  vars_files:
+    - vars/common-vars.yml
+  tasks:
+    - ansible.builtin.include_tasks: tasks/sshd-disable-tasks.yml
+      when: disable_sshd_after_install | bool

--- a/ansible/mke-install-playbook.yml
+++ b/ansible/mke-install-playbook.yml
@@ -41,9 +41,12 @@
     - ansible.builtin.include_tasks: tasks/mke-install-tasks.yml
 
 
-- name: Disable sshd on all hosts after MKE installation
+- name: Disable and stop sshd on all hosts after MKE installation
   hosts: all
   gather_facts: false
+  # When sshd is stopped the SSH transport drops before Ansible reads the result.
+  # ignore_unreachable suppresses the resulting connection error at the play level.
+  ignore_unreachable: true
   vars_files:
     - vars/common-vars.yml
   tasks:

--- a/ansible/mke-upgrade-playbook.yml
+++ b/ansible/mke-upgrade-playbook.yml
@@ -58,3 +58,14 @@
     - name: Run upgrade MKE tasks
       ansible.builtin.include_tasks: tasks/mke-upgrade-tasks.yml
       when: target_mke_version.stdout > current_mke_version.stdout or bootc_image_ref != ''
+
+
+- name: Disable and stop sshd on all hosts after MKE upgrade
+  hosts: all
+  gather_facts: false
+  ignore_unreachable: true
+  vars_files:
+    - vars/common-vars.yml
+  tasks:
+    - ansible.builtin.include_tasks: tasks/sshd-disable-tasks.yml
+      when: disable_sshd_after_install | bool

--- a/ansible/tasks/sshd-disable-tasks.yml
+++ b/ansible/tasks/sshd-disable-tasks.yml
@@ -1,0 +1,6 @@
+- name: Stop and disable sshd
+  ansible.builtin.systemd:
+    name: sshd
+    state: stopped
+    enabled: false
+  become: true

--- a/ansible/tasks/sshd-disable-tasks.yml
+++ b/ansible/tasks/sshd-disable-tasks.yml
@@ -4,7 +4,3 @@
     state: stopped
     enabled: false
   become: true
-  # ignore_errors covers the case where the module itself errors out.
-  # The SSH transport drops the moment sshd stops; ignore_unreachable on the
-  # play prevents Ansible from surfacing that as a fatal connection failure.
-  ignore_errors: true

--- a/ansible/tasks/sshd-disable-tasks.yml
+++ b/ansible/tasks/sshd-disable-tasks.yml
@@ -1,5 +1,10 @@
-- name: Disable sshd (takes effect on next boot, does not drop current connections)
+- name: Disable and stop sshd
   ansible.builtin.systemd:
     name: sshd
+    state: stopped
     enabled: false
   become: true
+  # ignore_errors covers the case where the module itself errors out.
+  # The SSH transport drops the moment sshd stops; ignore_unreachable on the
+  # play prevents Ansible from surfacing that as a fatal connection failure.
+  ignore_errors: true

--- a/ansible/tasks/sshd-disable-tasks.yml
+++ b/ansible/tasks/sshd-disable-tasks.yml
@@ -1,6 +1,5 @@
-- name: Stop and disable sshd
+- name: Disable sshd (takes effect on next boot, does not drop current connections)
   ansible.builtin.systemd:
     name: sshd
-    state: stopped
     enabled: false
   become: true

--- a/ansible/vars/common-vars.yml
+++ b/ansible/vars/common-vars.yml
@@ -26,6 +26,6 @@ mke_install_flags:
 main_manager: "{{ groups['managers'][0] }}"
 
 
-# When true, sshd is stopped and disabled on every host after MKE installation.
+# When true, sshd is stopped and disabled on every host at the end of the operation.
 # Set to true only in environments where SSH access must be revoked post-install.
 disable_sshd_after_install: false

--- a/ansible/vars/common-vars.yml
+++ b/ansible/vars/common-vars.yml
@@ -1,5 +1,5 @@
 # Optional Docker daemon configuration. The variable can be either file path or the Docker Daemon json content itself
-docker_daemon_config_src: "/Users/rkuzmin/workspace/projects/mkex-visa/bootc-mke3/ansible/vars/daemon.json"
+docker_daemon_config_src: ""
 
 # Optional Docker daemon configuration file path on remote hosts
 docker_daemon_config_dst: "/etc/docker/daemon.json"

--- a/ansible/vars/common-vars.yml
+++ b/ansible/vars/common-vars.yml
@@ -1,5 +1,5 @@
 # Optional Docker daemon configuration. The variable can be either file path or the Docker Daemon json content itself
-docker_daemon_config_src: ""
+docker_daemon_config_src: "/Users/rkuzmin/workspace/projects/mkex-visa/bootc-mke3/ansible/vars/daemon.json"
 
 # Optional Docker daemon configuration file path on remote hosts
 docker_daemon_config_dst: "/etc/docker/daemon.json"
@@ -24,3 +24,8 @@ mke_install_flags:
 
 # The appointed manager node used as a lead node
 main_manager: "{{ groups['managers'][0] }}"
+
+
+# When true, sshd is stopped and disabled on every host after MKE installation.
+# Set to true only in environments where SSH access must be revoked post-install.
+disable_sshd_after_install: false


### PR DESCRIPTION
   Adds a boolean variable `disable_sshd_after_install` (default: `false`) to`vars/common-vars.yml`. When set to `true`, a new play at the end of `mke-install-playbook.yml` stops and disables sshd on all hosts after MKE installation completes.

   The play sets `ignore_unreachable: true` to suppress the expected SSH connection drop that occurs when sshd is stopped. Real errors from the systemd module (e.g. unit not found, permission denied) still surface and fail the play.