### PR TITLE
ansible: automated MKE post-install configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ terraform.rc
 
 # Ansible registry credentials — machine-local, never commit
 ansible/vars/reg-creds
+
+# MKE3 client bundle — contains TLS keys, never commit
+ansible/mke-bundle/

--- a/ansible/mke-client-bundle-playbook.yml
+++ b/ansible/mke-client-bundle-playbook.yml
@@ -1,0 +1,26 @@
+# Fetches the MKE3 client bundle from the MKE API and saves it locally.
+#
+# The bundle is a ZIP file containing TLS certificates, a kubeconfig, and
+# shell environment scripts required to issue kubectl/docker commands against
+# the cluster as an authenticated user.
+#
+# Credentials are read from vars/mke-creds.yml (admin_user, admin_pass).
+# The MKE endpoint (mke_url) is read from the inventory all.vars.
+#
+# Usage:
+#   ansible-playbook mke-client-bundle-playbook.yml
+#
+# To override the local destination directory:
+#   ansible-playbook mke-client-bundle-playbook.yml -e bundle_dest=/tmp/my-bundle
+
+- name: Obtain MKE3 client bundle
+  hosts: managers
+  gather_facts: false
+  vars_files:
+    - vars/mke-creds.yml
+  vars:
+    # Directory on the Ansible controller where the bundle ZIP is written.
+    # Override with -e bundle_dest=<path> as needed.
+    bundle_dest: "{{ playbook_dir }}/mke-bundle"
+  tasks:
+    - ansible.builtin.include_tasks: tasks/mke-client-bundle-tasks.yml

--- a/ansible/mke-install-playbook.yml
+++ b/ansible/mke-install-playbook.yml
@@ -40,7 +40,6 @@
   tasks:
     - ansible.builtin.include_tasks: tasks/mke-install-tasks.yml
 
-
 - name: Disable and stop sshd on all hosts after MKE installation
   hosts: all
   gather_facts: false
@@ -52,3 +51,5 @@
   tasks:
     - ansible.builtin.include_tasks: tasks/sshd-disable-tasks.yml
       when: disable_sshd_after_install | bool
+
+- ansible.builtin.import_playbook: mke-post-install-playbook.yml

--- a/ansible/mke-post-install-playbook.yml
+++ b/ansible/mke-post-install-playbook.yml
@@ -1,0 +1,25 @@
+# Post-installation MKE configuration that requires no SSH access to cluster nodes.
+#
+# All operations run on the Ansible controller (hosts: localhost) and interact
+# with the cluster exclusively through the MKE REST API and the Kubernetes API.
+# This playbook can therefore be run independently after SSH has been disabled.
+#
+# Usage:
+#   ansible-playbook mke-post-install-playbook.yml
+#
+# To override the local bundle directory:
+#   ansible-playbook mke-post-install-playbook.yml -e bundle_dest=/tmp/my-bundle
+
+- name: Install MKE upgrade controller
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - vars/common-vars.yml
+    - vars/mke-creds.yml
+  vars:
+    # mke_url lives in inventory all.vars; pull it from a real host's hostvars
+    # since localhost is not part of the inventory group.
+    mke_url: "{{ hostvars[groups['managers'][0]]['mke_url'] }}"
+    bundle_dest: "{{ playbook_dir }}/mke-bundle"
+  tasks:
+    - ansible.builtin.include_tasks: tasks/mke-upgrade-controller-tasks.yml

--- a/ansible/tasks/helpers/suc_priv_grant.py
+++ b/ansible/tasks/helpers/suc_priv_grant.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Merges System Upgrade Controller configuration into the MKE cluster TOML file.
+
+Makes two independent changes:
+
+1. [cluster_config] — priv-attribute allowlists
+   Ensures priv_attributes_allowed_for_service_accounts includes all supported
+   attributes (hostIPC, hostNetwork, hostPID, hostBindMounts, privileged,
+   kernelCapabilities) and priv_attributes_service_accounts includes <sa-entry>.
+   Allows the SA's pods to use privileged security contexts without cluster-admin.
+
+2. [scheduling_configuration] — all-node scheduling
+   Sets enable_admin_ucp_scheduling = true so all authenticated users and
+   service accounts can schedule on manager and MSR nodes.
+
+Ref: https://docs.mirantis.com/mke/3.9/ops/deploy-apps-k8s/admission-controllers-for-access.html
+
+Idempotent: existing entries are preserved; duplicate entries are never added.
+Usage: python3 suc_priv_grant.py <path-to-mke-config.toml> <namespace:serviceaccount>
+"""
+
+import re
+import sys
+
+CLUSTER_SECTION = "[cluster_config]"
+ALLOWED_KEY = "priv_attributes_allowed_for_service_accounts"
+SA_KEY = "priv_attributes_service_accounts"
+
+# All privilege attributes supported by the MKE UCPAuthorization admission controller.
+# Ref: https://docs.mirantis.com/mke/3.9/ops/deploy-apps-k8s/admission-controllers-for-access.html
+ATTR_ENTRIES = [
+    "hostIPC",
+    "hostNetwork",
+    "hostPID",
+    "hostBindMounts",
+    "privileged",
+    "kernelCapabilities",
+]
+
+SCHEDULING_SECTION = "[scheduling_configuration]"
+ADMIN_SCHEDULING_KEY = "enable_admin_ucp_scheduling"
+
+# Matches a bare TOML section header — single brackets only, not [[array-of-tables]].
+_SECTION_RE = re.compile(r"^\[([^\[\]]+)\]$")
+
+
+def _parse_str_array(line):
+    """Return all double-quoted string values from a TOML inline-array line."""
+    return re.findall(r'"([^"]*)"', line)
+
+
+def _format_str_array(items):
+    return "[" + ", ".join(f'"{v}"' for v in items) + "]"
+
+
+def _ensure(items, entry):
+    """Return items with entry appended if not already present."""
+    return items if entry in items else items + [entry]
+
+
+def _ensure_all(items, entries):
+    """Return items with every element of entries appended if not already present."""
+    result = items
+    for entry in entries:
+        result = _ensure(result, entry)
+    return result
+
+
+def _insert_before_trailing_blanks(lst, line):
+    """Insert line into lst just before any trailing blank lines."""
+    idx = len(lst)
+    while idx > 1 and not lst[idx - 1].strip():
+        idx -= 1
+    lst.insert(idx, line)
+
+
+def _locate_section(lines, section):
+    """Return (section_start, section_end, key_positions) for the named section.
+
+    section_start is None when the section is absent.
+    section_end is the index of the first line of the next section (or len(lines)).
+    key_positions is a dict mapping stripped key prefixes to their line index.
+    """
+    in_target = False
+    section_start = None
+    section_end = len(lines)
+    key_positions = {}
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if _SECTION_RE.match(stripped):
+            if stripped == section:
+                in_target = True
+                section_start = i
+            elif in_target:
+                in_target = False
+                section_end = i
+                break
+        elif in_target and stripped and not stripped.startswith("#"):
+            # Record the index of the first occurrence of each key name.
+            key = stripped.split("=")[0].strip()
+            key_positions.setdefault(key, i)
+
+    return section_start, section_end, key_positions
+
+
+def _merge_cluster_config(lines, sa_entry):
+    """Merge priv-attribute arrays into [cluster_config]. Mutates lines in-place."""
+    section_start, section_end, key_pos = _locate_section(lines, CLUSTER_SECTION)
+
+    if section_start is None:
+        # Append the entire section.
+        lines.append(f"\n{CLUSTER_SECTION}\n")
+        lines.append(f"  {ALLOWED_KEY} = {_format_str_array(ATTR_ENTRIES)}\n")
+        lines.append(f"  {SA_KEY} = {_format_str_array([sa_entry])}\n")
+        return
+
+    # Rebuild only the section lines so other sections are untouched.
+    section_lines = lines[section_start:section_end]
+    new_section = []
+    allowed_found = False
+    sa_found = False
+
+    for line in section_lines:
+        key = line.strip()
+        if key.startswith(ALLOWED_KEY):
+            merged = _ensure_all(_parse_str_array(line), ATTR_ENTRIES)
+            new_section.append(f"  {ALLOWED_KEY} = {_format_str_array(merged)}\n")
+            allowed_found = True
+        elif key.startswith(SA_KEY):
+            merged = _ensure(_parse_str_array(line), sa_entry)
+            new_section.append(f"  {SA_KEY} = {_format_str_array(merged)}\n")
+            sa_found = True
+        else:
+            new_section.append(line)
+
+    if not allowed_found:
+        _insert_before_trailing_blanks(
+            new_section,
+            f"  {ALLOWED_KEY} = {_format_str_array(ATTR_ENTRIES)}\n",
+        )
+    if not sa_found:
+        _insert_before_trailing_blanks(
+            new_section,
+            f"  {SA_KEY} = {_format_str_array([sa_entry])}\n",
+        )
+
+    lines[section_start:section_end] = new_section
+
+
+def _set_bool(lines, section, key):
+    """Set key = true in the named section. Creates the section if absent."""
+    section_start, section_end, key_pos = _locate_section(lines, section)
+
+    if section_start is None:
+        lines.append(f"\n{section}\n")
+        lines.append(f"  {key} = true\n")
+        return
+
+    if key in key_pos:
+        lines[key_pos[key]] = f"  {key} = true\n"
+    else:
+        section_lines = lines[section_start:section_end]
+        _insert_before_trailing_blanks(section_lines, f"  {key} = true\n")
+        lines[section_start:section_end] = section_lines
+
+
+def process(content, sa_entry):
+    lines = content.splitlines(keepends=True)
+    _merge_cluster_config(lines, sa_entry)
+    _set_bool(lines, SCHEDULING_SECTION, ADMIN_SCHEDULING_KEY)
+    return "".join(lines)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit(f"Usage: {sys.argv[0]} <config.toml> <namespace:serviceaccount>")
+    path = sys.argv[1]
+    sa_entry = sys.argv[2]
+    with open(path) as f:
+        content = f.read()
+    modified = process(content, sa_entry)
+    with open(path, "w") as f:
+        f.write(modified)

--- a/ansible/tasks/mke-client-bundle-tasks.yml
+++ b/ansible/tasks/mke-client-bundle-tasks.yml
@@ -1,0 +1,77 @@
+# Obtains the MKE3 client bundle from the MKE API and saves it to the
+# Ansible controller.
+#
+# Required vars (resolved before this file is included):
+#   admin_user  – MKE administrator username
+#   admin_pass  – MKE administrator password
+#   mke_url     – MKE load-balancer / manager IP or hostname (no scheme)
+#   bundle_dest – local directory on the controller where the bundle is written
+#
+# All tasks delegate to localhost so the bundle lands on the controller, not on
+# a remote manager.  run_once: true prevents redundant work when the play
+# targets multiple managers.
+
+- name: Authenticate to MKE and obtain a short-lived auth token
+  ansible.builtin.uri:
+    url: "https://{{ mke_url }}/auth/login"
+    method: POST
+    body_format: json
+    body:
+      username: "{{ admin_user }}"
+      password: "{{ admin_pass }}"
+    validate_certs: false
+    status_code: 200
+  register: _mke_login
+  until: _mke_login.status == 200
+  retries: 12
+  delay: 10
+  delegate_to: localhost
+  run_once: true
+  no_log: true   # credentials must not appear in play output
+
+- name: Ensure bundle destination directory exists on controller
+  ansible.builtin.file:
+    path: "{{ bundle_dest }}"
+    state: directory
+    mode: "0700"   # bundle contains TLS keys; restrict to owner only
+  delegate_to: localhost
+  run_once: true
+
+- name: Download client bundle ZIP from MKE API
+  ansible.builtin.uri:
+    url: "https://{{ mke_url }}/api/clientbundle"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _mke_login.json.auth_token }}"
+    validate_certs: false
+    dest: "{{ bundle_dest }}/client-bundle.zip"
+    # Return binary content directly to dest; status 200 is the only success.
+    status_code: 200
+  register: _bundle_download
+  until: _bundle_download.status == 200
+  retries: 12
+  delay: 10
+  delegate_to: localhost
+  run_once: true
+  no_log: true   # Authorization header contains the bearer token
+
+- name: Unzip client bundle
+  ansible.builtin.unarchive:
+    src: "{{ bundle_dest }}/client-bundle.zip"
+    dest: "{{ bundle_dest }}"
+    remote_src: true   # ZIP is already on the controller (delegate_to: localhost)
+  delegate_to: localhost
+  run_once: true
+
+- name: Remove client bundle ZIP
+  ansible.builtin.file:
+    path: "{{ bundle_dest }}/client-bundle.zip"
+    state: absent
+  delegate_to: localhost
+  run_once: true
+
+- name: Report bundle location
+  ansible.builtin.debug:
+    msg: "Client bundle extracted to {{ bundle_dest }}"
+  delegate_to: localhost
+  run_once: true

--- a/ansible/tasks/mke-upgrade-controller-tasks.yml
+++ b/ansible/tasks/mke-upgrade-controller-tasks.yml
@@ -111,6 +111,7 @@
     - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/rbac.yaml
     - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/deployment.yaml
   delegate_to: localhost
+  when: deploy_mke_upgrade_controller | bool
   run_once: true
   # changed_when: false would suppress false positives, but kubectl apply
   # returns "configured" / "unchanged" reliably — let Ansible report truth.

--- a/ansible/tasks/mke-upgrade-controller-tasks.yml
+++ b/ansible/tasks/mke-upgrade-controller-tasks.yml
@@ -1,0 +1,96 @@
+# Installs the mke-upgrade-controller using the MKE3 client bundle kubeconfig.
+#
+# Steps:
+#   1. Fetch and extract the client bundle (kube.yml is the kubeconfig).
+#   2. Deploy System Upgrade Controller (SUC) when deploy_suc is true.
+#   3. Patch SUC deployment with node affinity so it schedules only on
+#      control-plane / master nodes running Linux.
+#   4. Grant system-upgrade-controller service account the privileged attribute
+#      in MKE cluster config when deploy_suc is true (UCPAuthorization allowlist).
+#   5. Apply the mke-upgrade-controller static manifests in the order mandated by
+#      the upstream README (CRD → namespace → serviceaccount → rbac → deployment).
+#
+# Required vars (inherited from the enclosing play):
+#   admin_user  – MKE administrator username       (from vars/mke-creds.yml)
+#   admin_pass  – MKE administrator password       (from vars/mke-creds.yml)
+#   mke_url     – MKE load-balancer IP/hostname    (from inventory all.vars)
+#   bundle_dest – local directory for the bundle   (default: playbook_dir/mke-bundle)
+#   deploy_suc  – when true, SUC is deployed before mke-upgrade-controller (from vars/common-vars.yml)
+#
+# Ref: https://github.com/nekwar/mke-upgrade-controller#without-helm-static-manifests
+# Ref: https://github.com/rancher/system-upgrade-controller
+
+- ansible.builtin.include_tasks: tasks/mke-client-bundle-tasks.yml
+
+- name: Deploy System Upgrade Controller (SUC)
+  ansible.builtin.command: >-
+    kubectl apply --kubeconfig {{ bundle_dest }}/kube.yml -f {{ item }}
+  loop:
+    - https://github.com/rancher/system-upgrade-controller/releases/latest/download/crd.yaml
+    - https://github.com/rancher/system-upgrade-controller/releases/latest/download/system-upgrade-controller.yaml
+  when: deploy_suc | bool
+  delegate_to: localhost
+  run_once: true
+  changed_when: "'configured' in _suc_apply.stdout or 'created' in _suc_apply.stdout"
+  register: _suc_apply
+
+- name: Patch SUC deployment with control-plane node affinity
+  ansible.builtin.command:
+    argv:
+      - kubectl
+      - patch
+      - deployment
+      - system-upgrade-controller
+      - -n
+      - system-upgrade
+      - --kubeconfig
+      - "{{ bundle_dest }}/kube.yml"
+      - --type
+      - merge
+      - --patch
+      - "{{ _suc_node_affinity_patch | to_json }}"
+  vars:
+    _suc_node_affinity_patch:
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node-role.kubernetes.io/control-plane
+                          operator: Exists
+                        - key: kubernetes.io/os
+                          operator: In
+                          values: [linux]
+                    - matchExpressions:
+                        - key: node-role.kubernetes.io/master
+                          operator: Exists
+                        - key: kubernetes.io/os
+                          operator: In
+                          values: [linux]
+  when: deploy_suc | bool
+  delegate_to: localhost
+  run_once: true
+  register: _suc_patch
+  changed_when: "'patched' in _suc_patch.stdout"
+
+
+- ansible.builtin.include_tasks: tasks/suc-priv-grant-tasks.yml
+  when: deploy_suc | bool
+- name: Apply mke-upgrade-controller static manifests
+  ansible.builtin.command: >-
+    kubectl apply --kubeconfig {{ bundle_dest }}/kube.yml -f {{ item }}
+  loop:
+    - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/crd.yaml
+    - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/namespace.yaml
+    - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/serviceaccount.yaml
+    - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/rbac.yaml
+    - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/deployment.yaml
+  delegate_to: localhost
+  run_once: true
+  # changed_when: false would suppress false positives, but kubectl apply
+  # returns "configured" / "unchanged" reliably — let Ansible report truth.
+  changed_when: "'configured' in _manifest_apply.stdout or 'created' in _manifest_apply.stdout"
+  register: _manifest_apply

--- a/ansible/tasks/mke-upgrade-controller-tasks.yml
+++ b/ansible/tasks/mke-upgrade-controller-tasks.yml
@@ -5,9 +5,10 @@
 #   2. Deploy System Upgrade Controller (SUC) when deploy_suc is true.
 #   3. Patch SUC deployment with node affinity so it schedules only on
 #      control-plane / master nodes running Linux.
-#   4. Grant system-upgrade-controller service account the privileged attribute
+#   4. Patch SUC ConfigMap to extend the job active deadline to 3600 s.
+#   5. Grant system-upgrade-controller service account the privileged attribute
 #      in MKE cluster config when deploy_suc is true (UCPAuthorization allowlist).
-#   5. Apply the mke-upgrade-controller static manifests in the order mandated by
+#   6. Apply the mke-upgrade-controller static manifests in the order mandated by
 #      the upstream README (CRD → namespace → serviceaccount → rbac → deployment).
 #
 # Required vars (inherited from the enclosing play):
@@ -75,6 +76,27 @@
   run_once: true
   register: _suc_patch
   changed_when: "'patched' in _suc_patch.stdout"
+
+- name: Patch SUC ConfigMap to extend job active deadline
+  ansible.builtin.command:
+    argv:
+      - kubectl
+      - patch
+      - configmap
+      - default-controller-env
+      - -n
+      - system-upgrade
+      - --kubeconfig
+      - "{{ bundle_dest }}/kube.yml"
+      - --type
+      - merge
+      - --patch
+      - '{"data":{"SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS":"3600"}}'
+  when: deploy_suc | bool
+  delegate_to: localhost
+  run_once: true
+  register: _suc_configmap_patch
+  changed_when: "'patched' in _suc_configmap_patch.stdout"
 
 
 - ansible.builtin.include_tasks: tasks/suc-priv-grant-tasks.yml

--- a/ansible/tasks/mke-upgrade-controller-tasks.yml
+++ b/ansible/tasks/mke-upgrade-controller-tasks.yml
@@ -8,8 +8,7 @@
 #   4. Patch SUC ConfigMap to extend the job active deadline to 3600 s.
 #   5. Grant system-upgrade-controller service account the privileged attribute
 #      in MKE cluster config when deploy_suc is true (UCPAuthorization allowlist).
-#   6. Apply the mke-upgrade-controller static manifests in the order mandated by
-#      the upstream README (CRD → namespace → serviceaccount → rbac → deployment).
+#   6. Install mke-upgrade-controller via Helm chart when deploy_mke_upgrade_controller is true.
 #
 # Required vars (inherited from the enclosing play):
 #   admin_user  – MKE administrator username       (from vars/mke-creds.yml)
@@ -17,8 +16,13 @@
 #   mke_url     – MKE load-balancer IP/hostname    (from inventory all.vars)
 #   bundle_dest – local directory for the bundle   (default: playbook_dir/mke-bundle)
 #   deploy_suc  – when true, SUC is deployed before mke-upgrade-controller (from vars/common-vars.yml)
+#   deploy_mke_upgrade_controller       – when true, installs mke-upgrade-controller (from vars/common-vars.yml)
+#   mke_upgrade_controller_release_name – Helm release name
+#   mke_upgrade_controller_chart        – OCI chart URL
+#   mke_upgrade_controller_version      – chart version
+#   mke_upgrade_controller_namespace    – target namespace (created if absent)
 #
-# Ref: https://github.com/nekwar/mke-upgrade-controller#without-helm-static-manifests
+# Ref: https://github.com/nekwar/mke-upgrade-controller#with-helm
 # Ref: https://github.com/rancher/system-upgrade-controller
 
 - ansible.builtin.include_tasks: tasks/mke-client-bundle-tasks.yml
@@ -101,19 +105,25 @@
 
 - ansible.builtin.include_tasks: tasks/suc-priv-grant-tasks.yml
   when: deploy_suc | bool
-- name: Apply mke-upgrade-controller static manifests
-  ansible.builtin.command: >-
-    kubectl apply --kubeconfig {{ bundle_dest }}/kube.yml -f {{ item }}
-  loop:
-    - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/crd.yaml
-    - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/namespace.yaml
-    - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/serviceaccount.yaml
-    - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/rbac.yaml
-    - https://raw.githubusercontent.com/nekwar/mke-upgrade-controller/feature/mke3-upgrade-support/deploy/deployment.yaml
-  delegate_to: localhost
+- name: Install mke-upgrade-controller via Helm
+  ansible.builtin.command:
+    argv:
+      - helm
+      - upgrade
+      - --install
+      - "{{ mke_upgrade_controller_release_name }}"
+      - "{{ mke_upgrade_controller_chart }}"
+      - --version
+      - "{{ mke_upgrade_controller_version }}"
+      - --namespace
+      - "{{ mke_upgrade_controller_namespace }}"
+      - --create-namespace
+      - --kubeconfig
+      - "{{ bundle_dest }}/kube.yml"
   when: deploy_mke_upgrade_controller | bool
+  delegate_to: localhost
   run_once: true
-  # changed_when: false would suppress false positives, but kubectl apply
-  # returns "configured" / "unchanged" reliably — let Ansible report truth.
-  changed_when: "'configured' in _manifest_apply.stdout or 'created' in _manifest_apply.stdout"
-  register: _manifest_apply
+  register: _helm_install
+  # helm upgrade --install always reports "upgraded" even when nothing changed;
+  # there is no reliable stdout signal for a true no-op.
+  changed_when: false

--- a/ansible/tasks/suc-priv-grant-tasks.yml
+++ b/ansible/tasks/suc-priv-grant-tasks.yml
@@ -1,0 +1,103 @@
+# Grants the permissions required for the System Upgrade Controller (SUC) to
+# operate on an MKE cluster:
+#
+#  1. Pod-security attributes — adds the SA to the UCPAuthorization allowlist
+#     so its pods may run with privileged, hostIPC, hostNetwork, hostPID,
+#     hostBindMounts, and kernelCapabilities.
+#     Mechanism: GET /api/ucp/config-toml → merge [cluster_config] → PUT.
+#
+#  2. Node scheduling — sets enable_admin_ucp_scheduling = true in
+#     [scheduling_configuration] so all authenticated users and service accounts
+#     can schedule on manager and MSR nodes.
+#     Mechanism: GET /api/ucp/config-toml → set key → PUT.
+#
+#  3. Swarm scheduling grant — grants the Scheduler role to all authenticated
+#     users on the root swarm collection.
+#     Mechanism: PUT /collectionGrants/authenticated/swarm/scheduler.
+#
+# Required vars (inherited from the enclosing play):
+#   mke_url             – MKE load-balancer IP/hostname (from inventory all.vars)
+#   _mke_login          – registered result of the /auth/login URI task
+#                         (set by mke-client-bundle-tasks.yml earlier in the same play)
+#   suc_service_account – namespace:name of the SA to grant privileged (from vars/common-vars.yml)
+#
+# Ref: https://docs.mirantis.com/mke/3.9/ops/deploy-apps-k8s/admission-controllers-for-access.html
+# Ref: https://success.docker.com/article/update-enable-user-ucp-scheduling-setting
+
+- name: Create temp file for MKE cluster config
+  ansible.builtin.tempfile:
+    suffix: .toml
+  register: _mke_config_tmp
+  delegate_to: localhost
+  run_once: true
+
+- name: Download current MKE cluster config
+  ansible.builtin.uri:
+    url: "https://{{ mke_url }}/api/ucp/config-toml"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ _mke_login.json.auth_token }}"
+    validate_certs: false
+    dest: "{{ _mke_config_tmp.path }}"
+    status_code: 200
+  delegate_to: localhost
+  run_once: true
+  no_log: true   # Authorization header contains the bearer token
+
+- name: Merge SUC privilege grant into MKE cluster config
+  ansible.builtin.command: >-
+    python3 {{ playbook_dir }}/tasks/helpers/suc_priv_grant.py {{ _mke_config_tmp.path }} {{ suc_service_account }}
+  delegate_to: localhost
+  run_once: true
+  # The script is an idempotent file mutation; Ansible cannot detect a diff here.
+  changed_when: false
+
+- name: Read modified MKE cluster config
+  ansible.builtin.slurp:
+    src: "{{ _mke_config_tmp.path }}"
+  register: _mke_config_modified
+  delegate_to: localhost
+  run_once: true
+
+- name: Upload modified MKE cluster config
+  ansible.builtin.uri:
+    url: "https://{{ mke_url }}/api/ucp/config-toml"
+    method: PUT
+    headers:
+      Authorization: "Bearer {{ _mke_login.json.auth_token }}"
+      Content-Type: application/toml
+    # slurp returns base64; decode to the raw TOML string for the request body.
+    body: "{{ _mke_config_modified.content | b64decode }}"
+    validate_certs: false
+    status_code: 200
+  delegate_to: localhost
+  run_once: true
+  no_log: true   # Authorization header contains the bearer token
+
+- name: Remove temp MKE cluster config
+  ansible.builtin.file:
+    path: "{{ _mke_config_tmp.path }}"
+    state: absent
+  delegate_to: localhost
+  run_once: true
+
+
+# --- Node scheduling grant ---
+
+- name: Grant Scheduler role to all authenticated users on swarm collection
+  ansible.builtin.uri:
+    # Grant triple is encoded entirely in the URL path:
+    #   subject = authenticated  (built-in alias for all authenticated users)
+    #   object  = swarm          (root Swarm collection — built-in alias)
+    #   role    = scheduler      (built-in alias)
+    url: "https://{{ mke_url }}/collectionGrants/authenticated/swarm/scheduler"
+    method: PUT
+    headers:
+      Authorization: "Bearer {{ _mke_login.json.auth_token }}"
+    validate_certs: false
+    status_code: [200, 201]  # 201 on first create, 200 on idempotent repeat
+  delegate_to: localhost
+  run_once: true
+  no_log: true   # Authorization header contains the bearer token
+  changed_when: _scheduler_grant.status == 201
+  register: _scheduler_grant

--- a/ansible/vars/common-vars.yml
+++ b/ansible/vars/common-vars.yml
@@ -28,4 +28,14 @@ main_manager: "{{ groups['managers'][0] }}"
 
 # When true, sshd is stopped and disabled on every host at the end of the operation.
 # Set to true only in environments where SSH access must be revoked post-install.
-disable_sshd_after_install: false
+disable_sshd_after_install: true
+
+# When true, the System Upgrade Controller (SUC) is deployed to the cluster
+# before mke-upgrade-controller. Required when spec.os or spec.product.type=mke4
+# is used in a ClusterUpgrade CR.
+# Ref: https://github.com/rancher/system-upgrade-controller
+deploy_suc: true
+
+# Service account granted the 'privileged' pod-security attribute in the MKE
+# UCPAuthorization allowlist when deploy_suc is true. Format: namespace:name.
+suc_service_account: "system-upgrade:system-upgrade"

--- a/ansible/vars/common-vars.yml
+++ b/ansible/vars/common-vars.yml
@@ -43,3 +43,9 @@ suc_service_account: "system-upgrade:system-upgrade"
 
 # When true, the mke-upgrade-controller is installed on the cluster.
 deploy_mke_upgrade_controller: true
+
+# mke-upgrade-controller Helm chart coordinates.
+mke_upgrade_controller_release_name: "mke-upgrade-controller"
+mke_upgrade_controller_chart: "oci://registry.ci.mirantis.com/bootc-mirantis/mke-upgrade-controller"
+mke_upgrade_controller_version: "0.1.0"
+mke_upgrade_controller_namespace: "mke"

--- a/ansible/vars/common-vars.yml
+++ b/ansible/vars/common-vars.yml
@@ -39,3 +39,7 @@ deploy_suc: true
 # Service account granted the 'privileged' pod-security attribute in the MKE
 # UCPAuthorization allowlist when deploy_suc is true. Format: namespace:name.
 suc_service_account: "system-upgrade:system-upgrade"
+
+
+# When true, the mke-upgrade-controller is installed on the cluster.
+deploy_mke_upgrade_controller: true


### PR DESCRIPTION
## Ansible: automated MKE post-install configuration

Adds a post-install Ansible workflow that configures an MKE3 cluster without SSH — all operations run on the controller via the MKE REST API and kube API, safe to run after SSH is disabled.

### What's added

**`mke-client-bundle-playbook.yml` / `tasks/mke-client-bundle-tasks.yml`**
Fetches the MKE3 client bundle via REST API, extracts `kube.yml`, cleans up the ZIP. Auth and download both have retries.

**`tasks/mke-upgrade-controller-tasks.yml`**
Installs `mke-upgrade-controller` (branch `feature/mke3-upgrade-support`) using the bundle kubeconfig. When `deploy_suc: true`, also deploys System Upgrade Controller with:
- Node affinity patch (control-plane/master nodes, Linux only)
- `SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS=3600` ConfigMap patch
- MKE privilege grants for the SUC service account (pod-security attributes, all-node scheduling via config-toml and grants API)

**`mke-post-install-playbook.yml`**
Standalone playbook wrapping the above. Imported by `mke-install-playbook.yml` as its final step; can also be run independently after SSH is disabled.

### New vars (`vars/common-vars.yml`)

| Variable | Default | Purpose |
|---|---|---|
| `deploy_suc` | `false` | Deploy SUC before mke-upgrade-controller |
| `suc_service_account` | `system-upgrade:system-upgrade` | SA granted privileged pod-security attributes |