### PR TITLE
ansible: add disable_firewalld variable and update port management

### DIFF
--- a/ansible/mke-install-playbook.yml
+++ b/ansible/mke-install-playbook.yml
@@ -1,11 +1,16 @@
 - name: Write Docker daemon config file to remote hosts
   ansible.builtin.import_playbook: mcr-setup-docker.yml
 
-- name: Open required MKE ports
+- name: Ports management
   gather_facts: false
   hosts: all
+  vars_files:
+    - vars/common-vars.yml
   tasks:
+    - ansible.builtin.include_tasks: tasks/firewalld-disable-tasks.yml
+      when: disable_firewalld | bool
     - ansible.builtin.include_tasks: tasks/mke-open-ports-tasks.yml
+      when: not disable_firewalld | bool
 
 - name: Init Swarm cluster control plane
   hosts: managers

--- a/ansible/mke-upgrade-playbook.yml
+++ b/ansible/mke-upgrade-playbook.yml
@@ -1,11 +1,16 @@
 - name: Setup up Docker on remote hosts
   ansible.builtin.import_playbook: mcr-setup-docker.yml
 
-- name: Open required MKE ports
+- name: Ports management
   gather_facts: false
   hosts: all
+  vars_files:
+    - vars/common-vars.yml
   tasks:
+    - ansible.builtin.include_tasks: tasks/firewalld-disable-tasks.yml
+      when: disable_firewalld | bool
     - ansible.builtin.include_tasks: tasks/mke-open-ports-tasks.yml
+      when: not disable_firewalld | bool
 
 - name: Backup MKE before upgrade
   ansible.builtin.import_playbook: mke-backup-playbook.yml

--- a/ansible/tasks/firewalld-disable-tasks.yml
+++ b/ansible/tasks/firewalld-disable-tasks.yml
@@ -1,0 +1,6 @@
+- name: Stop and disable firewalld
+  ansible.builtin.systemd:
+    name: firewalld
+    state: stopped
+    enabled: false
+  become: true

--- a/ansible/vars/common-vars.yml
+++ b/ansible/vars/common-vars.yml
@@ -30,6 +30,12 @@ main_manager: "{{ groups['managers'][0] }}"
 # Set to true only in environments where SSH access must be revoked post-install.
 disable_sshd_after_install: true
 
+# When true, firewalld is stopped and disabled on every host instead of opening
+# individual ports. Use in environments where the network perimeter is managed
+# externally and a host-level firewall adds no value or causes interference.
+# When false (default), the standard per-service port rules are applied via firewalld.
+disable_firewalld: false
+
 # When true, the System Upgrade Controller (SUC) is deployed to the cluster
 # before mke-upgrade-controller. Required when spec.os or spec.product.type=mke4
 # is used in a ClusterUpgrade CR.
@@ -46,6 +52,6 @@ deploy_mke_upgrade_controller: true
 
 # mke-upgrade-controller Helm chart coordinates.
 mke_upgrade_controller_release_name: "mke-upgrade-controller"
-mke_upgrade_controller_chart: "oci://registry.ci.mirantis.com/bootc-mirantis/mke-upgrade-controller"
+mke_upgrade_controller_chart: "oci://registry.ci.mirantis.com/bootc-mirantis/charts/mke-upgrade-controller"
 mke_upgrade_controller_version: "0.1.0"
 mke_upgrade_controller_namespace: "mke"


### PR DESCRIPTION
- Add disable_firewalld var to vars/common-vars.yml (default: false). When true, firewalld is stopped and disabled on every host. When false, standard per-service firewalld port rules are applied.
- Add tasks/firewalld-disable-tasks.yml to stop and disable firewalld.
- Add vars_files to 'Ports management' play in both playbooks (was missing, making any variable-gated condition unreachable at runtime).
- Gate mke-open-ports-tasks.yml and firewalld-disable-tasks.yml includes on disable_firewalld in mke-install and mke-upgrade playbooks.
- Rename play 'Open required MKE ports' -> 'Ports management'.
- Update mke_upgrade_controller_chart URL to include /charts/ path segment.