### PR TITLE
Update assets to MCR 29.4.1 / MKE 3.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Mirantis provides assets for provisioning `bootc-mke3` on different providers. A
 
 | Type  | Download link | Description | Mirantis product's version |
 | :---- | ------------- | ----------- | -------------------------- |
-| ISO   | [Link](https://get.mirantis.com/bootc-mke3/images/bootc-mke3-r9-bare-mcr29.2-mke3.9-simple.iso)      | **Simple** ISO with basic kickstart embedded. Unattended Anaconda installation will be performed. See [this document](docs/iso-editions.md#simple) to get more details about Simple image edition. | MCR 29.2.1 / MKE 3.9.0 |
-| ISO   | [Link](https://get.mirantis.com/bootc-mke3/images/bootc-mke3-r9-bare-mcr29.2-mke3.9-generic.iso)      | **Generic** ISO without any customisation. See [this document](docs/iso-editions.md#generic-image-customisation.md) to get the details on how to properly customise it | MCR 29.2.1 / MKE 3.9.0 |
-| QCOW2 | [Link](https://get.mirantis.com/bootc-mke3/images/bootc-mke3-r9-cloud-mcr29.2-mke3.9.qcow2)      | Standard QEMU/KVM bootable image | MCR 29.2.1 / MKE 3.9.0 |
+| ISO   | [Link](https://get.mirantis.com/bootc-mke3/images/bootc-mke3-r9-bare-mcr29.4-mke3.9-simple.iso)      | **Simple** ISO with basic kickstart embedded. Unattended Anaconda installation will be performed. See [this document](docs/iso-editions.md#simple) to get more details about Simple image edition. | MCR 29.4.1 / MKE 3.9.4 |
+| ISO   | [Link](https://get.mirantis.com/bootc-mke3/images/bootc-mke3-r9-bare-mcr29.4-mke3.9-generic.iso)      | **Generic** ISO without any customisation. See [this document](docs/iso-editions.md#generic-image-customisation.md) to get the details on how to properly customise it | MCR 29.4.1 / MKE 3.9.4 |
+| QCOW2 | [Link](https://get.mirantis.com/bootc-mke3/images/bootc-mke3-r9-cloud-mcr29.4-mke3.9.qcow2)      | Standard QEMU/KVM bootable image | MCR 29.4.1 / MKE 3.9.4 |
 
 > [!NOTE]
 > **Simple** ISO edition is used mostly for demo/test purposes. For production-grade clusters consider susing **Generic** ISO.


### PR DESCRIPTION
Automated update: bumps README assets table to MCR 29.4.1 / MKE 3.9.4.\n\nGenerated by the Jenkins release pipeline.